### PR TITLE
Ensure UserAccess handles missing directories

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,2 @@
+"""Package marker for src modules."""
+

--- a/src/user_access.py
+++ b/src/user_access.py
@@ -14,6 +14,9 @@ class UserAccess:
         Garante que o arquivo de banco de dados JSON exista.
         """
         try:
+            db_dir = os.path.dirname(self.db_path)
+            if db_dir and not os.path.exists(db_dir):
+                os.makedirs(db_dir, exist_ok=True)
             if not os.path.exists(self.db_path):
                 with open(self.db_path, 'w') as db_file:
                     json.dump([], db_file)
@@ -60,7 +63,7 @@ class UserAccess:
                 users = json.load(db_file)
 
             if not users:
-                return "Nenhum usuário encontrado. Por favor, cadastre-se primeiro."
+                return "Email ou senha incorretos."
 
             for user in users:
                 if user['email'] == email and user['password'] == password:

--- a/tests/test_user_access.py
+++ b/tests/test_user_access.py
@@ -1,7 +1,12 @@
 import unittest
-from src.user_access import UserAccess
 import os
 import json
+import shutil
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.user_access import UserAccess
 
 class TestUserAccess(unittest.TestCase):
 
@@ -55,6 +60,20 @@ class TestUserAccess(unittest.TestCase):
         """
         response = self.user_access.login_user("invalid@email.com", "wrongpassword")
         self.assertEqual(response, "Email ou senha incorretos.")
+
+    def test_creates_missing_directory(self):
+        """Garante que diretórios inexistentes sejam criados automaticamente."""
+        temp_dir = "data/temp_databases"
+        temp_db_path = os.path.join(temp_dir, "users.json")
+
+        if os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir)
+
+        UserAccess(db_path=temp_db_path)
+        self.assertTrue(os.path.exists(temp_db_path))
+
+        if os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Summary
- ensure user database directory is created automatically before use
- standardize login failures when no users exist
- add test for creating missing directories and enable importing `src`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689380576bf88326a39373da8f8b1b17