### PR TITLE
Process N8N JSON exports through Layer 1 formatter

### DIFF
--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integration modules for SWAI."""

--- a/integrations/database/__init__.py
+++ b/integrations/database/__init__.py
@@ -1,0 +1,1 @@
+"""Database integrations for SWAI."""

--- a/integrations/database/sqlite_manager.py
+++ b/integrations/database/sqlite_manager.py
@@ -1,0 +1,105 @@
+"""SQLite manager used for persisting messages in the SWAI Lite database."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, Optional
+
+
+class SWAILiteManager:
+    """Lightweight wrapper around :mod:`sqlite3`.
+
+    The class is purposely small, providing only the required
+    functionality for this project: ensuring the database schema exists
+    and inserting formatted messages into the ``messages`` table.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        """Create the ``messages`` table if it doesn't exist."""
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    message_id TEXT UNIQUE,
+                    sender_phone TEXT,
+                    receiver_phone TEXT,
+                    sender_type TEXT,
+                    content TEXT,
+                    timestamp TEXT
+                )
+                """
+            )
+
+    def store_message(self, message: Dict[str, Any], overwrite: bool = False) -> Optional[int]:
+        """Store a formatted message into the database.
+
+        Parameters
+        ----------
+        message:
+            Dictionary containing the canonical message fields.
+        overwrite:
+            When ``True`` existing records with the same ``message_id``
+            are replaced; otherwise they are left untouched.
+
+        Returns
+        -------
+        Optional[int]
+            The row ID of the inserted (or existing) message. ``None`` is
+            returned if insertion was ignored.
+        """
+
+        columns = (
+            "message_id",
+            "sender_phone",
+            "receiver_phone",
+            "sender_type",
+            "content",
+            "timestamp",
+        )
+        values = tuple(message.get(col) for col in columns)
+
+        with self.conn:
+            if overwrite:
+                cursor = self.conn.execute(
+                    """
+                    INSERT INTO messages (message_id, sender_phone, receiver_phone, sender_type, content, timestamp)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(message_id) DO UPDATE SET
+                        sender_phone=excluded.sender_phone,
+                        receiver_phone=excluded.receiver_phone,
+                        sender_type=excluded.sender_type,
+                        content=excluded.content,
+                        timestamp=excluded.timestamp
+                    """,
+                    values,
+                )
+                return cursor.lastrowid
+
+            cursor = self.conn.execute(
+                """
+                INSERT OR IGNORE INTO messages (message_id, sender_phone, receiver_phone, sender_type, content, timestamp)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                values,
+            )
+
+            if cursor.rowcount == 0:
+                # Record already existed; fetch its ID for reference
+                existing = self.conn.execute(
+                    "SELECT id FROM messages WHERE message_id = ?",
+                    (message["message_id"],),
+                ).fetchone()
+                return existing["id"] if existing else None
+
+            return cursor.lastrowid
+
+    def close(self) -> None:
+        self.conn.close()
+

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Data processing pipeline for SWAI WhatsApp analysis."""

--- a/pipeline/layer1_formatter.py
+++ b/pipeline/layer1_formatter.py
@@ -1,0 +1,86 @@
+"""Layer 1 formatter for N8N webhook messages.
+
+This module contains helper utilities to translate raw messages
+received from the N8N webhook into a normalized structure that can be
+stored into the SWAI Lite database.  The formatter is intentionally
+minimal and focuses on the most common fields emitted by WhatsApp
+through the official Cloud API.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+
+class Layer1FormatError(Exception):
+    """Raised when the raw message lacks required information."""
+
+
+def _extract_content(data: Dict[str, Any]) -> str:
+    """Return the textual content from a raw message dictionary.
+
+    The WhatsApp webhook may encode the message body in different
+    structures depending on its type.  This helper attempts to read the
+    message text in a tolerant manner and falls back to an empty string
+    when it cannot be determined.
+    """
+
+    if "text" in data and isinstance(data["text"], dict):
+        return data["text"].get("body", "")
+    if "body" in data:
+        return str(data["body"])
+    if "content" in data:
+        return str(data["content"])
+    return ""
+
+
+def _normalize_timestamp(value: Any) -> str:
+    """Normalize raw timestamp values to an ISO formatted string."""
+
+    if value is None:
+        raise Layer1FormatError("timestamp ausente")
+
+    # Unix timestamps may come as integers or digit strings
+    if isinstance(value, (int, float)) or (isinstance(value, str) and value.isdigit()):
+        return datetime.fromtimestamp(int(value)).isoformat()
+
+    # Attempt to parse ISO formatted strings; if parsing fails, keep raw
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value).isoformat()
+        except ValueError:
+            return value
+
+    raise Layer1FormatError(f"formato de timestamp inválido: {value!r}")
+
+
+def format_message(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a dictionary with the canonical SWAI message fields.
+
+    Parameters
+    ----------
+    data:
+        Raw message dictionary produced by the N8N webhook.  The
+        dictionary **must** contain at least ``id`` and ``timestamp``
+        fields.  ``from`` and ``to`` are used to identify sender and
+        receiver phone numbers.
+    """
+
+    message_id = data.get("id") or data.get("message_id")
+    if not message_id:
+        raise Layer1FormatError("message_id ausente")
+
+    timestamp = _normalize_timestamp(data.get("timestamp"))
+
+    formatted = {
+        "message_id": message_id,
+        "sender_phone": data.get("from"),
+        "receiver_phone": data.get("to"),
+        "sender_type": data.get("sender_type"),
+        "content": _extract_content(data),
+        "timestamp": timestamp,
+    }
+
+    return formatted
+

--- a/pipeline/layer1_formatter.py
+++ b/pipeline/layer1_formatter.py
@@ -43,7 +43,7 @@ def _normalize_timestamp(value: Any) -> str:
 
     # Unix timestamps may come as integers or digit strings
     if isinstance(value, (int, float)) or (isinstance(value, str) and value.isdigit()):
-        return datetime.fromtimestamp(int(value)).isoformat()
+        return datetime.fromtimestamp(int(value), tz=timezone.utc).isoformat()
 
     # Attempt to parse ISO formatted strings; if parsing fails, keep raw
     if isinstance(value, str):

--- a/scripts/process_n8n_json_layer1.py
+++ b/scripts/process_n8n_json_layer1.py
@@ -1,0 +1,77 @@
+"""Process N8N exported JSON files applying Layer 1 formatting.
+
+This script iterates over a directory containing JSON payloads captured
+by the N8N webhook.  Each payload is expected to have the same
+structure used by the production webhook where the message data resides
+under the ``data`` key.  The formatted messages are stored in a SQLite
+database using :class:`SWAILiteManager`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from integrations.database.sqlite_manager import SWAILiteManager
+from pipeline.layer1_formatter import Layer1FormatError, format_message
+
+
+logger = logging.getLogger(__name__)
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def process_directory(directory: Path, db_path: Path, force: bool = False) -> None:
+    manager = SWAILiteManager(str(db_path))
+    for file_path in sorted(directory.glob("*.json")):
+        try:
+            payload = _load_json(file_path)
+            if "data" not in payload:
+                raise Layer1FormatError("campo 'data' ausente")
+            formatted = format_message(payload["data"])
+            row_id = manager.store_message(formatted, overwrite=force)
+            if row_id:
+                msg = f"✅ processado: {file_path.name} → ID: {row_id}"
+            else:
+                msg = f"⚠️ já existente: {file_path.name}"
+            logger.info(msg)
+            print(msg)
+        except Exception as exc:  # pragma: no cover - log path
+            err = f"❌ erro ao processar {file_path.name}: {exc}"
+            logger.error(err)
+            print(err)
+    manager.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="data/n8n_exports",
+        help="Diretório com os arquivos JSON exportados pelo N8N",
+    )
+    parser.add_argument(
+        "--db",
+        default="data/databases/messages.db",
+        help="Caminho do arquivo SQLite que receberá os dados",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Reprocessa mensagens já inseridas",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    process_directory(Path(args.directory), Path(args.db), force=args.force)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Layer 1 formatter to normalize N8N webhook messages
- introduce SWAILiteManager for SQLite persistence
- script to iterate over N8N JSON exports, format and store messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6893ec4408c883268590ef403deab231