### PR TITLE
feat: add n8n raw data integration

### DIFF
--- a/integrations/n8n/n8n_raw_data.json
+++ b/integrations/n8n/n8n_raw_data.json
@@ -1,0 +1,12 @@
+[
+  {
+    "host_n8n": "host.docker.internal:5678",
+    "evo_api_instance_name": "WAB-Diego Menescal",
+    "host_evoapi": "http://localhost:8080",
+    "sender_raw_data": "5511999168646@s.whatsapp.net",
+    "receiver_raw_data": "5511998681314@s.whatsapp.net",
+    "message_type": "conversation",
+    "sent_message": "Boa Lee, parabéns e vamo que vamo. Abs",
+    "timestamp": "2025-08-07T15:11:40.978Z"
+  }
+]

--- a/pipeline/layer2_grouper.py
+++ b/pipeline/layer2_grouper.py
@@ -23,9 +23,13 @@ def configure(manager: SWAILiteManager) -> None:
 def _extract_phones(message: Dict[str, Any]) -> tuple[str, str]:
     """Return ``(lead_phone, secretary_phone)`` from a formatted message."""
 
-    if message.get("sender_type") == "lead":
+    sender_type = message.get("sender_type")
+    if sender_type == "lead":
         return message.get("sender_phone"), message.get("receiver_phone")
-    return message.get("receiver_phone"), message.get("sender_phone")
+    if sender_type == "secretary":
+        return message.get("receiver_phone"), message.get("sender_phone")
+    # Default assumption: sender is the lead when type is unknown
+    return message.get("sender_phone"), message.get("receiver_phone")
 
 
 def process_layer2_grouping(formatted_message: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add real Evolution API sample data for n8n
- parse and normalize n8n webhook messages, including phone and message type
- handle missing sender type in conversation grouper
- add integration test storing n8n data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894f693ca2883269a6736f00fc90b8d